### PR TITLE
ENH: Update epic.md to include two sections under epic qualification

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -21,7 +21,7 @@ about: Create an epic from a set of issues. WP Developers and Product Managers O
 
 ### Design
 
-- [ ] **User pain points**. Mention the current user pain points that the epic will solve. Use this to provide context.
+- [ ] **User pain points**. Mention the key pain points this epic will solve, along with current workarounds.
 - [ ] **Solving the pain points**. Explain how this epic addresses and resolves the pain points.
 - [ ] **Mockups**. Where frontend is involved, add mockups and/or prototypes in the epic or a direct link.
 - [ ] **Data structure**. For cross-service data items, define JSONSchema and link(s) added here.
@@ -29,6 +29,7 @@ about: Create an epic from a set of issues. WP Developers and Product Managers O
 - [ ] **User Journeys**. Where external users (eg W&S team / GIS team / Clients) will use the feature, user journey flow diagrams must be complete and linked to from here or the relevant subissues.
 - [ ] **Permission charts**. If relevant (eg permissions resources are affected), create or update the relevant permissions chart and link to it from here.
 - [ ] **Workflow definition**. If a background / async workflow is required, add a workflow diagram or text-based definition, placed either directly in a subissue or link it from here.
+- [ ] **Estimated effort** In tabular format, provide a breakdown of the time required to complete each sub-task or sub-feature in the epic. Note this is high level estimate.
 
 ### Contents
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -29,7 +29,7 @@ about: Create an epic from a set of issues. WP Developers and Product Managers O
 - [ ] **User Journeys**. Where external users (eg W&S team / GIS team / Clients) will use the feature, user journey flow diagrams must be complete and linked to from here or the relevant subissues.
 - [ ] **Permission charts**. If relevant (eg permissions resources are affected), create or update the relevant permissions chart and link to it from here.
 - [ ] **Workflow definition**. If a background / async workflow is required, add a workflow diagram or text-based definition, placed either directly in a subissue or link it from here.
-- [ ] **Estimated effort** In tabular format, provide a breakdown of the time required to complete each sub-task or sub-feature in the epic. Note this is high level estimate.
+- [ ] **Estimated effort**. In tabular format, provide a breakdown of the time required to complete each sub-task or sub-feature in the epic. Note this is high level estimate.
 
 ### Contents
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -21,6 +21,8 @@ about: Create an epic from a set of issues. WP Developers and Product Managers O
 
 ### Design
 
+- [ ] **User pain points**. Mention the current user pain points that the epic will solve. Use this to provide context.
+- [ ] **Solving the pain points**. Explain how this epic addresses and resolves the pain points.
 - [ ] **Mockups**. Where frontend is involved, add mockups and/or prototypes in the epic or a direct link.
 - [ ] **Data structure**. For cross-service data items, define JSONSchema and link(s) added here.
 - [ ] **Sample data files**. If any data files are involved, these should be added to / linked from the relevant subissues (eg the issues for file readers/writers/storage).


### PR DESCRIPTION
Added two sections: User pain points and Solving pain points that are to be included in the Epic qualification slide deck

<!---

PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything (although you can edit release notes afterward).

Anything added between the auto-generation marker comments below will be re-generated on every push, so make sure to add anything you want to keep outside of them.

--->

<!--- START AUTOGENERATED NOTES --->
<!--- END AUTOGENERATED NOTES --->
